### PR TITLE
Move the linux test to a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,13 @@ USER root
 
 # Basics
 RUN apt-get update && apt-get install -y \
- git \
- curl \
  xvfb \
- wget
+ wget \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN mkdir /fcuitest
 COPY . /fcuitest/ 
-
-RUN alias ls='ls -al'
 
 ENV LEIN_ROOT true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,31 @@
-FROM centos:7
+FROM selenium/standalone-chrome:2.46.0
 
-RUN curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/bin/lein
-RUN chmod 755 /usr/bin/lein
+MAINTAINER Silver Team <silver@broadinstitute.org>
 
-RUN echo -e '[google-chrome]\n\
-name=google-chrome\n\
-baseurl=http://dl.google.com/linux/chrome/rpm/stable/$basearch\n\
-enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub\n\
-' > /etc/yum.repos.d/google-chrome.repo
+USER root
 
-RUN yum -y install  google-chrome-stable unzip GConf2 java-1.8.0-openjdk && yum clean all
+# Basics
+RUN apt-get update && apt-get install -y \
+ git \
+ curl \
+ xvfb \
+ wget
 
-ADD resources /usr/firecloud-ui-browser-tests/resources
-ADD scripts /usr/firecloud-ui-browser-tests/scripts
-ADD src /usr/firecloud-ui-browser-tests/src
-ADD test  /usr/firecloud-ui-browser-tests/test
-ADD project.clj /usr/firecloud-ui-browser-tests/
-ADD profiles.clj /usr/firecloud-ui-browser-tests/
-WORKDIR /usr/firecloud-ui-browser-tests/
+RUN mkdir /fcuitest
+COPY . /fcuitest/ 
 
-#RUN lein clean
-#RUN ./scripts/test.sh linux
+RUN alias ls='ls -al'
 
+ENV LEIN_ROOT true
+
+RUN wget -q -O /usr/bin/lein \
+    https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein \
+    && chmod +x /usr/bin/lein
+
+# Clean project
+WORKDIR /fcuitest
+RUN lein clean
+
+# Test Execution
+WORKDIR /fcuitest
+RUN xvfb-run lein with-profile docker test

--- a/README.md
+++ b/README.md
@@ -12,10 +12,28 @@
 * [Cursive Intellij Plugin](https://cursiveclojure.com/userguide/index.html)
 * [Chrome Drivers](http://chromedriver.storage.googleapis.com/index.html)
 
-### Run all tests:
+### Testing
+
+Testing can be done locally by running a script that will download the chrome driver file and run the tests 
+pointing to that driver:
 
     lein clean
     ./scripts/test.sh mac
+    
+Alternatively, the tests can be run from the docker file. To do this, you'll need a working instance of 
+docker (and boot2docker for mac users) installed. Make sure docker is up and responding before trying to run
+the docker shell command.
+     
+* [Docker Getting Started](https://docs.docker.com/mac/started/)
+* [Boot2Docker Installation](https://docs.docker.com/mac/step_one/)
+* [Docker Reference](http://docs.docker.com/reference/builder/)
+
+Boot2Docker does not like our vpn client, Cisco AnyConnect. If you run into timeout issues, see this SO post:
+[http://stackoverflow.com/questions/26686358/docker-cant-connect-to-boot2docker-because-of-tcp-timeout](http://stackoverflow.com/questions/26686358/docker-cant-connect-to-boot2docker-because-of-tcp-timeout)
+
+The command for running tests using in docker is
+
+    ./scripts/test.sh docker                   
 
 ### Sample Output:
 
@@ -45,12 +63,14 @@ urls, such as localhost, development, or production.
 Chrome testing requires a binary chrome driver file (os specific versions are included in the resources directory).
 One can run tests without those by running against firefox. Firefox is better-supported by Selenium than other
 browsers, but DSDE has chosen Chrome as the supported browser so we do need to test against Chrome as a priority
-and other browsers if needed. In `org.broadinstitute.dsde.firecloud.util.clj`, change `chrome` to `firefox`.
+and other browsers if needed. In `org.broadinstitute.dsde.firecloud.util.clj`, change `chrome` to `firefox`. 
+
+*Note:* Changing the browser from chrome to firefox may break the docker build as it is customized for chrome.
 
 Separate profiles are configured for each major platform, linux, mac, and win. Run all tests with the profile 
 specific to your environment:
 
-* `./scripts/test.sh linux`
+* `./scripts/test.sh docker`
 * `./scripts/test.sh mac`
 * `./scripts/test.sh win`
 

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,5 +1,5 @@
 {
- :linux {:jvm-opts ["-Dwebdriver.chrome.driver=./target/chromedriver"]}
+ :docker {:jvm-opts ["-Dwebdriver.chrome.driver=/opt/selenium/chromedriver-2.16"]}
  :mac {:jvm-opts ["-Dwebdriver.chrome.driver=./target/chromedriver"]}
  :win {:jvm-opts ["-Dwebdriver.chrome.driver=./target/chromedriver.exe"]}
  }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ DO_testDocker() {
     echo "## Testing in Docker ##"
     echo "#######################"
     echo ""
-    docker build -t fc/fcuitest .
+    docker build --no-cache=true -t fc-fcuitest .
 }
 
 DO_testMac() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,12 +12,11 @@ IFS=$'\n\t'
 EXPECTED_ARGS=1
 E_BADARGS=64
 
-lin_url="http://chromedriver.storage.googleapis.com/2.15/chromedriver_linux64.zip"
 mac_url="http://chromedriver.storage.googleapis.com/2.15/chromedriver_mac32.zip"
 win_url="http://chromedriver.storage.googleapis.com/2.15/chromedriver_win32.zip"
 
 DO_showUsage() {
-    echo "Usage: $(basename $0) {linux|mac|win}"
+    echo "Usage: $(basename $0) {docker|mac|win}"
     exit $E_BADARGS
 }
 
@@ -25,17 +24,13 @@ if [ $# -ne $EXPECTED_ARGS ]; then
     DO_showUsage
 fi
 
-DO_testLinux() {
+DO_testDocker() {
     echo ""
-    echo "######################"
-    echo "## Testing on Linux ##"
-    echo "######################"
+    echo "#######################"
+    echo "## Testing in Docker ##"
+    echo "#######################"
     echo ""
-    mkdir -p target
-    if [ ! -f target/chromedriver ]; then
-        curl -sS $lin_url > target/driver.zip && unzip target/driver.zip && rm target/driver.zip && mv chromedriver target/
-    fi
-    lein with-profile linux test
+    docker build -t fc/fcuitest .
 }
 
 DO_testMac() {
@@ -65,8 +60,8 @@ DO_testWin() {
 }
 
 case "$1" in
-    linux)
-        DO_testLinux
+    docker)
+        DO_testDocker
         ;;
     mac)
         DO_testMac


### PR DESCRIPTION
Update docker file to act as the test container.
Update documentation and script to run tests either locally or headless through the docker image.
